### PR TITLE
MediumTest deprecated

### DIFF
--- a/app/templates/screen/ActivityTests.kt.mustache
+++ b/app/templates/screen/ActivityTests.kt.mustache
@@ -1,7 +1,5 @@
 package {{package}}.ui.{{screenLowerCase}};
 
-import android.test.suitebuilder.annotation.MediumTest;
-
 import {{package}}.EspressoTestRule;
 import {{package}}.MainApplicationDaggerMockRule;
 import {{package}}.R;
@@ -18,7 +16,6 @@ import java.util.regex.Pattern;
 
 import rx.Observable;
 
-@MediumTest
 class {{screenUpperCamel}}ActivityEspressoTests {
 
     @Rule val mockitoRule = MainApplicationDaggerMockRule()


### PR DESCRIPTION
suitebuilder.annotation.MediumTest deprecated.  Removing to match Java template.

Could add: https://developer.android.com/reference/android/support/test/filters/MediumTest.html to both templates instead of removing it here. 