### PR TITLE
Fix/gradle app screen

### DIFF
--- a/app/generator.gradle
+++ b/app/generator.gradle
@@ -66,7 +66,7 @@ task screen << {
 
 task ktscreen << {
     String argPackage = getProject().getProperty('package')
-    String argPackageDirs = argPackage.replaceAll("\\.", File.separator);
+    String argPackageDirs = argPackage.replaceAll("\\.", Matcher.quoteReplacement(File.separator));
 
     String argScreen = getProject().getProperty('screen')
     String screenPackage = argScreen.toLowerCase()

--- a/app/generator.gradle
+++ b/app/generator.gradle
@@ -4,6 +4,8 @@
 import com.github.mustachejava.DefaultMustacheFactory
 import com.google.common.base.CaseFormat
 
+import java.util.regex.Matcher
+
 buildscript {
     repositories {
         mavenCentral()
@@ -17,7 +19,7 @@ buildscript {
 
 task screen << {
     String argPackage = getProject().getProperty('package')
-    String argPackageDirs = argPackage.replaceAll("\\.", File.separator);
+    String argPackageDirs = argPackage.replaceAll("\\.", Matcher.quoteReplacement(File.separator));
 
     String argScreen = getProject().getProperty('screen')
     String screenPackage = argScreen.toLowerCase()


### PR DESCRIPTION
## This PR will:
* Fix issues with the `app:screen` gradle task not working on Windows. I believe the issue was that File.separator on Windows returns a single backslash, which when running `string.replaceAll` was having issues properly escaping.
<br/>Now, by using java.util.regex.matcher, `Matcher.quoteReplacement(File.separator)` will return `/` on Unix-like systems and return `\\` on Windows. [Details on the solution I found are available here](http://stackoverflow.com/questions/13714722/replaceall-with-file-separator)