### PR TITLE
fix/dev-flavor-no-backup

### DIFF
--- a/app/src/dev/AndroidManifest.xml
+++ b/app/src/dev/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <application>
+    <application
+        android:allowBackup="false"
+        tools:replace="android:allowBackup">
         <activity
             android:name="com.mycompany.myapp.ui.devsettings.DevSettingsActivity"
             android:label="@string/dev_settings"


### PR DESCRIPTION
## This PR:
* Added application tag to dev manifest to prevent app data from being backed up and restored for dev builds on Android 6 and up.