### PR TITLE
- Removed explicit splash screen and replaced w/ SplashScreen API (Wo…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -163,6 +163,7 @@ ext {
 
     mlBarcodeScannerVersion = '17.0.2'
     camerax_version = '1.2.0-alpha04'
+    splashVersion = "1.0.0"
 }
 
 dependencies {
@@ -293,6 +294,7 @@ dependencies {
     implementation "androidx.camera:camera-extensions:${camerax_version}"
 
     implementation "androidx.constraintlayout:constraintlayout-compose:${compose_constraint_version}"
+    implementation "androidx.core:core-splashscreen:${splashVersion}"
 }
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,13 +12,13 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme.App.Starting">
         <activity
             android:name=".StartActivity"
             android:exported="true"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/title_activity_compose_start"
-            android:theme="@style/AppTheme">
+            android:theme="@style/AppTheme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/atomicrobot/carbon/StartActivity.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/StartActivity.kt
@@ -20,14 +20,14 @@ class StartActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
-        val isDeepLinkIntent = handleIntent(intent)
+        handleIntent(intent)
 
         setContent {
             CarbonAndroidTheme {
                 // Wrap the composable in a LocalActivity provider so our composable 'environment'
                 // has access to Activity context/scope which is required for requesting permissions
                 CompositionLocalProvider(LocalActivity provides this) {
-                    MainNavigation(isDeepLinkIntent)
+                    MainNavigation()
                 }
             }
         }

--- a/app/src/main/java/com/atomicrobot/carbon/StartActivity.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/StartActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.atomicrobot.carbon.ui.compose.LocalActivity
 import com.atomicrobot.carbon.ui.compose.MainNavigation
 import com.atomicrobot.carbon.ui.splash.SplashViewModel
@@ -17,6 +18,7 @@ class StartActivity : ComponentActivity() {
     private val splashViewModel: SplashViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
         val isDeepLinkIntent = handleIntent(intent)
 
@@ -51,7 +53,6 @@ class StartActivity : ComponentActivity() {
 
     companion object {
         const val mainPage = "mainScreen"
-        const val splashPage = "splashScreen"
         const val deepLinkPath1 = "deepLinkPath1"
     }
 }

--- a/app/src/main/java/com/atomicrobot/carbon/deeplink/DeepLinkInteractor.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/deeplink/DeepLinkInteractor.kt
@@ -3,6 +3,7 @@ package com.atomicrobot.carbon.deeplink
 import android.graphics.Color
 import android.net.Uri
 import com.atomicrobot.carbon.StartActivity
+import com.atomicrobot.carbon.navigation.AppScreens
 import timber.log.Timber
 import java.lang.NumberFormatException
 
@@ -23,7 +24,7 @@ class DeepLinkInteractor {
             when (path) {
                 "/carbon-android" -> {
                     Timber.d("default deep link received")
-                    return StartActivity.mainPage
+                    return AppScreens.Home.route
                 }
                 "/carbon-android/path1" -> {
                     Timber.d("path1 deep link received")
@@ -31,7 +32,7 @@ class DeepLinkInteractor {
                 }
                 else -> {
                     Timber.e("Deep link path not recognized")
-                    return StartActivity.mainPage
+                    return AppScreens.Home.route
                 }
             }
         }

--- a/app/src/main/java/com/atomicrobot/carbon/navigation/AppScreens.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/navigation/AppScreens.kt
@@ -7,6 +7,9 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
+import androidx.navigation.navDeepLink
 import com.atomicrobot.carbon.R
 
 sealed class AppScreens(val title: String, val route: String, val iconData: ScreenIcon) {
@@ -39,7 +42,42 @@ sealed class AppScreens(val title: String, val route: String, val iconData: Scre
         "Deep Link",
         "deepLinkPath1",
         ScreenIcon(Icons.Filled.QrCodeScanner, R.string.cont_desc_scanner_icon)
-    )
+    ) {
+
+        const val textColor = "textColor"
+        const val textSize = "textSize"
+        const val path = "path"
+
+        val routeWithArgs = "deepLink/{$path}"
+
+        val arguments = listOf(
+            navArgument(path) {
+                nullable = false
+                type = NavType.StringType
+            },
+            navArgument(textColor) {
+                nullable = true
+                type = NavType.StringType
+                defaultValue = "black"
+            },
+            navArgument(textSize) {
+                nullable = true
+                type = NavType.StringType
+                defaultValue = "30"
+            }
+        )
+        val deepLink = listOf(
+            navDeepLink {
+                uriPattern = "atomicrobot://carbon-android/{$path}?textSize={$textSize}&textColor={$textColor}"
+            },
+            navDeepLink {
+                uriPattern = "http://www.atomicrobot.com/carbon-android/{$path}?textSize={$textSize}&textColor={$textColor}"
+            },
+            navDeepLink {
+                uriPattern = "https://www.atomicrobot.com/carbon-android/{$path}?textSize={$textSize}&textColor={$textColor}"
+            },
+        )
+    }
 }
 
 data class ScreenIcon(val icon: ImageVector, @StringRes val iconContentDescription: Int)

--- a/app/src/main/java/com/atomicrobot/carbon/ui/compose/MainNavigation.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/ui/compose/MainNavigation.kt
@@ -31,10 +31,8 @@ import com.atomicrobot.carbon.ui.deeplink.DeepLinkSampleScreen
 import com.atomicrobot.carbon.ui.main.MainScreen
 import com.atomicrobot.carbon.ui.scanner.ScannerScreen
 import com.atomicrobot.carbon.ui.settings.Settings
-import com.atomicrobot.carbon.ui.splash.SplashViewModel
 import com.google.mlkit.vision.barcode.common.Barcode
 import kotlinx.coroutines.launch
-import org.koin.androidx.compose.getViewModel
 import timber.log.Timber
 
 private val screens = listOf(
@@ -44,8 +42,7 @@ private val screens = listOf(
 )
 
 @Composable
-fun MainNavigation(isDeepLinkIntent: Boolean) {
-    val viewModel: SplashViewModel = getViewModel()
+fun MainNavigation() {
     val navController = rememberNavController()
     val scope = rememberCoroutineScope()
     val scaffoldState: ScaffoldState = rememberScaffoldState()
@@ -59,42 +56,36 @@ fun MainNavigation(isDeepLinkIntent: Boolean) {
     Scaffold(
         topBar =
         {
-            // Hide the top app bar during splash screen transition
-            if (showAppBar(navBackStackEntry)) {
-                TopBar(
-                    title = appBarTitle(navBackStackEntry),
-                    buttonIcon = Icons.Filled.Menu,
-                    onButtonClicked = {
-                        scope.launch {
-                            scaffoldState.drawerState.open()
-                        }
+            TopBar(
+                title = appBarTitle(navBackStackEntry),
+                buttonIcon = Icons.Filled.Menu,
+                onButtonClicked = {
+                    scope.launch {
+                        scaffoldState.drawerState.open()
                     }
-                )
-            }
+                }
+            )
         },
         bottomBar =
         {
-            // Hide the bottom bar during splash screen transition
-            if (showAppBar(navBackStackEntry)) {
-                BottomNavigationBar(
-                    navController = navController,
-                    destinations = screens,
-                    onDestinationClicked = {
-                        if (navController.currentBackStackEntry?.destination?.route != it.route) {
-                            navController.navigate(it.route) {
-                                // Make sure the back stack only consists of the current graphs main
-                                // destination
-                                popUpTo(AppScreens.Home.route) {
-                                    saveState = true
-                                }
-                                // Singular instance of destinations
-                                launchSingleTop = true
-                                restoreState = true
+            BottomNavigationBar(
+                navController = navController,
+                destinations = screens,
+                onDestinationClicked = {
+                    if (navController.currentBackStackEntry?.destination?.route != it.route) {
+                        navController.navigate(it.route) {
+                            // Make sure the back stack only consists of the current graphs main
+                            // destination
+                            popUpTo(AppScreens.Home.route) {
+                                saveState = true
                             }
+                            // Singular instance of destinations
+                            launchSingleTop = true
+                            restoreState = true
                         }
                     }
-                )
-            }
+                }
+            )
         },
         drawerContent =
         {
@@ -121,7 +112,7 @@ fun MainNavigation(isDeepLinkIntent: Boolean) {
             navController = navController,
             startDestination = "Main"
         ) {
-            mainFlowGraph(navController, scaffoldState, isDeepLinkIntent, viewModel)
+            mainFlowGraph(navController, scaffoldState)
         }
     }
 }
@@ -132,9 +123,7 @@ fun MainNavigation(isDeepLinkIntent: Boolean) {
 @Suppress("UNUSED_PARAMETER")
 fun NavGraphBuilder.mainFlowGraph(
     navController: NavHostController,
-    scaffoldState: ScaffoldState,
-    isDeepLinkIntent: Boolean,
-    viewModel: SplashViewModel
+    scaffoldState: ScaffoldState
 ) {
     navigation(startDestination = AppScreens.Home.route, route = "Main") {
         composable(AppScreens.Home.route) {
@@ -195,11 +184,6 @@ fun NavGraphBuilder.mainFlowGraph(
             )
         }
     }
-}
-
-@Composable
-fun showAppBar(navBackStackEntry: NavBackStackEntry?): Boolean {
-    return navBackStackEntry?.destination?.route != AppScreens.SplashScreen.route
 }
 
 @Composable

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,5 @@
     <color name="colorPrimaryDark">#303F9F</color>
     <color name="colorAccent">#FF4081</color>
     <color name="blue">#FF0000FF</color>
+    <color name="appicon_background">#26A69A</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,4 +17,10 @@
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light"/>
+
+    <style name="AppTheme.App.Starting" parent="Theme.SplashScreen.IconBackground">
+        <item name="windowSplashScreenIconBackgroundColor">@color/appicon_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="postSplashScreenTheme">@style/AppTheme</item>
+    </style>
 </resources>


### PR DESCRIPTION
# Changelog
- Removed explicit splash screen. App relies on the default splash screen provided by the OS. On Android versions below 12, the app relies on the SplashScreen Jetpack lib.

- Added native Compose-navigation deep-linking support.

## Changed
- app/build.gradle
- app/src/main/AndroidManifest.xml
- app/src/main/java/com/atomicrobot/carbon/StartActivity.kt 
- app/src/main/java/com/atomicrobot/carbon/deeplink/DeepLinkInteractor.kt
- app/src/main/java/com/atomicrobot/carbon/navigation/AppScreens.kt 
- app/src/main/java/com/atomicrobot/carbon/ui/compose/MainNavigation.kt 
- app/src/main/res/values/colors.xml 
- app/src/main/res/values/styles.xml

## Is there test coverage for your changes?
 No
